### PR TITLE
Update SmartyRenderer.php

### DIFF
--- a/src/SmartyModule/View/Renderer/SmartyRenderer.php
+++ b/src/SmartyModule/View/Renderer/SmartyRenderer.php
@@ -133,6 +133,7 @@ class SmartyRenderer extends PhpRenderer
                     $this->__template
                 ));
             }
+            $this->smarty->setTemplateDir(dirname($this->__file));
             $this->__content = $this->smarty->fetch($this->__file);
         }
         return $this->getFilterChain()->filter($this->__content); // filter output


### PR DESCRIPTION
Setting Smarty template dir before fetching template content can open ability to use {include} in templates. Thx pkaso
